### PR TITLE
Add pyproject.toml for Custom Node Registry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[project]
+name = "nodegpt"
+description = "Implementation of AutoGen inside ComfyUI. This repository is under development, and not everything is functioning correctly yet."
+version = "1.0.0"
+license = "LICENSE"
+dependencies = ["pyautogen>0.2", "pymemgpt", "llama-cpp-python", "Pillow<10", "websockets<12.0"]
+
+[project.urls]
+Repository = "https://github.com/xXAdonesXx/NodeGPT"
+#  Used by Comfy Registry https://comfyregistry.org
+
+[tool.comfy]
+PublisherId = ""
+DisplayName = "NodeGPT"
+Icon = ""


### PR DESCRIPTION
We are building a global registry for custom nodes (similar to PyPI). The registry makes using custom nodes more reliable by reserving globally unique names for each custom node, and supporting semantic versioning.

Here’s some [more information](https://comfydocs.org/registry/overview#introduction) on the registry.

Action Required:

- [ ] Go to the [registry](https://comfyregistry.org/). Login and create a publisher id. Comment it here and we will update the PR (or just merge it and change it yourself).
- [ ] Write a short the description.
- [ ] Merge the separate Github Actions PR and run the workflow.

If you want to publish the node manually, [install the cli](https://comfydocs.org/comfy-cli/getting-started#install-cli) and run `comfy node publish`
Please message me on [Discord](https://discord.com/invite/comfyorg) if you have any questions!